### PR TITLE
Make results consistent, add utf-16be

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@borewit/text-codec",
       "version": "0.2.1",
       "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.14.0"
+      },
       "devDependencies": {
         "@biomejs/biome": "2.3.10",
         "@types/chai": "^5.2.2",
@@ -196,6 +199,23 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.14.0.tgz",
+      "integrity": "sha512-YiY1OmY6Qhkvmly8vZiD8wZRpW/npGZNg+0Sk8mstxirRHCg6lolHt5tSODCfuNPE/fBsAqRwDJE417x7jDDHA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -1400,7 +1420,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1414,7 +1433,8 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
       "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -66,5 +66,8 @@
     "type": "github",
     "url": "https://github.com/sponsors/Borewit"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "@exodus/bytes": "^1.14.0"
+  }
 }

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,10 +1,27 @@
 import { expect } from "chai";
+import { toHex } from "@exodus/bytes/hex.js";
 import { textEncode, textDecode, type SupportedEncoding } from '../lib/index.js';
+
+const nonUtf8 = [
+  { bytes: [0, 254, 255], charcodes: [0, 0xff_fd, 0xff_fd] },
+  { bytes: [0x80], charcodes: [0xff_fd] },
+  { bytes: [0xf0, 0x90, 0x80], charcodes: [0xff_fd] },
+  { bytes: [0xf0, 0x80, 0x80], charcodes: [0xff_fd, 0xff_fd, 0xff_fd] },
+]
+
+const orphans = [
+  { charcodes: [0x61, 0x62, 0xd8_00, 0x77, 0x78], replaced: [0x61, 0x62, 0xff_fd, 0x77, 0x78], utf8: '6162efbfbd7778' },
+  { charcodes: [0xd8_00], replaced: [0xff_fd], utf8: 'efbfbd' },
+  { charcodes: [0xd8_00, 0xd8_00], replaced: [0xff_fd, 0xff_fd], utf8: 'efbfbdefbfbd' },
+  { charcodes: [0x61, 0x62, 0xdf_ff, 0x77, 0x78], replaced: [0x61, 0x62, 0xff_fd, 0x77, 0x78], utf8: '6162efbfbd7778' },
+  { charcodes: [0xdf_ff, 0xd8_00], replaced: [0xff_fd, 0xff_fd], utf8: 'efbfbdefbfbd' },
+]
 
 describe("Text polyfill encode/decode", () => {
   const encodings: [SupportedEncoding, string][] = [
     ["utf-8", "Hello 🌍"],
     ["utf-16le", "Hello 🌍"],
+    ["utf-16be", "Hello 🌍"],
     ["ascii", "Hello!"],
     ["latin1", "Héllo ¢"],
     ["windows-1252", "Hello €—World"],
@@ -30,6 +47,24 @@ describe("Text polyfill encode/decode", () => {
       const str = "𝄞"; // U+1D11E
       expect(textDecode(textEncode(str, "utf-8"), "utf-8")).to.equal(str);
     });
+    it("should ignore (not remove) BOM", () => {
+      expect(textDecode(Uint8Array.of(0xef, 0xbb, 0xbf), "utf-8"), "utf-8").to.equal("\uFEFF");
+      expect(textDecode(Uint8Array.of(0xef, 0xbb, 0xbf, 0x42), "utf-8"), "utf-8").to.equal("\uFEFFB");
+    });
+    it("textDecode replacement", () => {
+      for (const { bytes, charcodes } of nonUtf8) {
+        const string = String.fromCharCode(...charcodes)
+        expect(textDecode(Uint8Array.from(bytes), "utf-8")).to.equal(string);
+        expect(textDecode(textEncode(string, "utf-8"), "utf-8")).to.equal(string);
+      }
+    });
+    it("textEncode replacement", () => {
+      for (const { charcodes, replaced, utf8 } of orphans) {
+        const bytes = textEncode(String.fromCharCode(...charcodes), "utf-8");
+        expect(toHex(bytes)).to.equal(utf8);
+        expect(textDecode(bytes, "utf-8")).to.equal(String.fromCharCode(...replaced));
+      }
+    });
   });
 
   describe("UTF-16LE", () => {
@@ -40,6 +75,67 @@ describe("Text polyfill encode/decode", () => {
     it("should handle emoji", () => {
       const str = "😀";
       expect(textDecode(textEncode(str, "utf-16le"), "utf-16le")).to.equal(str);
+    });
+    it("should ignore (not remove) BOM", () => {
+      expect(textDecode(Uint8Array.of(0xff, 0xfe), "utf-16le"), "utf-16le").to.equal("\uFEFF");
+      expect(textDecode(Uint8Array.of(0xff, 0xfe, 0x42, 0), "utf-16le"), "utf-16le").to.equal("\uFEFFB");
+    });
+    it("textDecode replacement", () => {
+      for (const { charcodes, replaced } of orphans) {
+        const bytes = new Uint8Array(replaced.length * 2);
+        const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+        for (let i = 0; i < charcodes.length; i++) view.setUint16(i * 2, charcodes[i], true);
+        const string = String.fromCharCode(...replaced);
+        expect(textDecode(bytes, "utf-16le")).to.equal(string);
+        expect(textDecode(textEncode(string, "utf-16le"), "utf-16le")).to.equal(string);
+      }
+    });
+    it("textEncode replacement", () => {
+      for (const { charcodes, replaced } of orphans) {
+        const bytes = textEncode(String.fromCharCode(...charcodes), "utf-16le");
+        const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+        expect(view.byteLength).to.equal(replaced.length * 2);
+        for (let i = 0; i < replaced.length; i++) {
+          expect(view.getUint16(i * 2, true)).to.equal(replaced[i]);
+        }
+        expect(textDecode(bytes, "utf-16le")).to.equal(String.fromCharCode(...replaced));
+      }
+    });
+  });
+
+  describe("UTF-16BE", () => {
+    it("should handle BMP chars", () => {
+      const str = "ABC";
+      expect(textDecode(textEncode(str, "utf-16be"), "utf-16be")).to.equal(str);
+    });
+    it("should handle emoji", () => {
+      const str = "😀";
+      expect(textDecode(textEncode(str, "utf-16be"), "utf-16be")).to.equal(str);
+    });
+    it("should ignore (not remove) BOM", () => {
+      expect(textDecode(Uint8Array.of(0xfe, 0xff), "utf-16be"), "utf-16be").to.equal("\uFEFF");
+      expect(textDecode(Uint8Array.of(0xfe, 0xff, 0, 0x42), "utf-16be"), "utf-16be").to.equal("\uFEFFB");
+    });
+    it("textDecode replacement", () => {
+      for (const { charcodes, replaced } of orphans) {
+        const bytes = new Uint8Array(replaced.length * 2);
+        const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+        for (let i = 0; i < charcodes.length; i++) view.setUint16(i * 2, charcodes[i], false);
+        const string = String.fromCharCode(...replaced);
+        expect(textDecode(bytes, "utf-16be")).to.equal(string);
+        expect(textDecode(textEncode(string, "utf-16be"), "utf-16be")).to.equal(string);
+      }
+    });
+    it("textEncode replacement", () => {
+      for (const { charcodes, replaced } of orphans) {
+        const bytes = textEncode(String.fromCharCode(...charcodes), "utf-16be");
+        const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+        expect(view.byteLength).to.equal(replaced.length * 2);
+        for (let i = 0; i < replaced.length; i++) {
+          expect(view.getUint16(i * 2, false)).to.equal(replaced[i]);
+        }
+        expect(textDecode(bytes, "utf-16be")).to.equal(String.fromCharCode(...replaced));
+      }
     });
   });
 


### PR DESCRIPTION
Fixes #30

1. UTF-8 and UTF-16 now _ignore_ BOM on both native and fallback versions.
   Assuming that was the intention as that's how fallback was written in 0.2.1
2. UTF-8 and UTF-16 now perform replacement properly in fallback.
   That's what native version is doing already, so this normalizes native and fallback.
   Also that's what e.g. ASCII codec is doing here - it shapes invalid (non-ASCII) input to ASCII.
3. Add UTF-16BE support
4. UTF-16 is now significantly faster
5. UTF-8 is now significantly faster in polyfill, e.g. Hermes
6. Add tests

This brings in [@exodus/bytes](https://npmjs.com/package/@exodus/bytes) dependency, authored by me, for the implementation. It choses best impl based on platform and is very heavily tested (including but not limited to passing [WPT](https://github.com/web-platform-tests/wpt)), with cross-tests, on all platforms.

Alternatively, you can copy parts of the impl (I do recommend keeping these tests in some form though)